### PR TITLE
fix small typo add requirements.txt

### DIFF
--- a/collect_texts.py
+++ b/collect_texts.py
@@ -47,7 +47,7 @@ for i, j in thank_you.iterrows():
 	else:
 		pass
 	if url not in all_urls:
-		untracked_url.append(url)
+		untracked_urls.append(url)
 	elif url in all_urls:
 		select_index = [i for i, value in enumerate(all_urls) if value == url]
 		if len(select_index) == 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+beautifulsoup4
+ocrmypdf
+pandas
+pdfminer
+pip
+pyfiglet
+requests
+selenium
+setuptools
+tldextract
+wheel


### PR DESCRIPTION
Thanks for sharing, I've been meaning to look at beautiful soup for a while.

Looks like there is a typo on line 50 of collect_texts.py

Added requirements.txt to capture dependencies to easily install via `pip install -r requirements.txt` especially convenient if using conda environments to avoid cluttering main python env. 

This also required `liblept5` and `firefox-geckodriver` installed via apt on ubuntu before anything would run. Maybe I'll try to document the full set via a `Dockerfile` as I'm sure there are other dependencies I already had installed.

There appear to be other issues I'm struggling through, not sure if user error, documentation, or something other. I'll try to grok things a bit better so I can articulate the other issues and either create issues or PRs. 

